### PR TITLE
fixed prmopts in the llm_agent

### DIFF
--- a/specs_ai/llm_agent.py
+++ b/specs_ai/llm_agent.py
@@ -78,14 +78,19 @@ def _build_prompt(specs: dict[str, Any]) -> str:
 
     return (
         "You are an expert PC hardware technician.\n"
-        "The user wants to know the best upgrades for their exact machine.\n"
+        "The user wants upgrade recommendations for their exact machine.\n"
         "Be specific: name actual part models and explain the real-world benefit "
         "of each upgrade. Prioritise by impact-per-dollar. Be concise.\n\n"
-        "Current specs:\n"
+        "Known specs (this is the complete set of components retrieved from the machine):\n"
         "---\n"
         f"{specs_block}\n"
         "---\n\n"
-        "What are the best upgrade paths for this machine?"
+        "IMPORTANT: Only recommend upgrades for the components listed above "
+        "(CPU, RAM, GPU, Motherboard). "
+        "Do NOT mention, assume, or speculate about components that are not listed "
+        "(e.g. storage, PSU, cooling, peripherals). "
+        "If you have no meaningful upgrade recommendation for a listed component, skip it.\n\n"
+        "What are the best upgrade paths for the components listed above?"
     )
 
 

--- a/tests/test_llm_agent.py
+++ b/tests/test_llm_agent.py
@@ -96,6 +96,20 @@ def test_build_prompt_is_ascii_safe() -> None:
     prompt.encode("ascii")  # raises UnicodeEncodeError if any non-ASCII present
 
 
+def test_build_prompt_restricts_to_listed_components() -> None:
+    """Prompt must instruct the LLM not to recommend unlisted components."""
+    prompt = _build_prompt(_SAMPLE_SPECS)
+    assert "Do NOT mention, assume, or speculate about components that are not listed" in prompt
+    assert "storage" in prompt  # must name at least one excluded category
+
+
+def test_build_prompt_scopes_closing_question() -> None:
+    """Closing question must be scoped to listed components, not open-ended."""
+    prompt = _build_prompt(_SAMPLE_SPECS)
+    assert "components listed above" in prompt
+    assert "What are the best upgrade paths for this machine?" not in prompt
+
+
 # ---- _format_value ----------------------------------------------------------
 
 


### PR DESCRIPTION
New prompt explicitly restricts the LLM to only the components in the spec block (CPU, RAM, GPU, Motherboard). When adding a new hardware component, update both `extractor.py` (collection) **and** `llm_agent._build_prompt`:
add the new component to `specs_block` and remove its category from the exclusion list in the IMPORTANT clause

Fixes #2 